### PR TITLE
fix: endpoint body type inference

### DIFF
--- a/packages/ts-endpoint-express/src/__typetests__/__snapshots__/addEndpoint.typespec.ts.snap
+++ b/packages/ts-endpoint-express/src/__typetests__/__snapshots__/addEndpoint.typespec.ts.snap
@@ -18,6 +18,6 @@ exports[`won't compile if output oc controller is wrong (type) should match snap
                 Type 'number' is not assignable to type 'string'."
 `;
 
-exports[`won't compile if trying to access non defined body (type) should match snapshot 1`] = `"Property 'foo' does not exist on type '{}'."`;
+exports[`won't compile if trying to access non defined body (type) should match snapshot 1`] = `"Property 'foo' does not exist on type 'undefined'."`;
 
 exports[`won't compile if trying to access non existent param (type) should match snapshot 1`] = `"Property 'baz' does not exist on type 'CodecRecordOutput<{ auth: StringC; }>'."`;

--- a/packages/ts-endpoint-express/src/__typetests__/__snapshots__/addEndpoint.typespec.ts.snap
+++ b/packages/ts-endpoint-express/src/__typetests__/__snapshots__/addEndpoint.typespec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`correct constructions should work (type) should match snapshot 1`] = `"void"`;
 
+exports[`correct constructions should work (type) should match snapshot 2`] = `"void"`;
+
 exports[`should not allow empty calls (type) should match snapshot 1`] = `"Expected at least 1 arguments, but got 0."`;
 
 exports[`won't compile if output oc controller is wrong (type) should match snapshot 1`] = `

--- a/packages/ts-endpoint-express/src/__typetests__/__snapshots__/addEndpoint.typespec.ts.snap
+++ b/packages/ts-endpoint-express/src/__typetests__/__snapshots__/addEndpoint.typespec.ts.snap
@@ -18,6 +18,6 @@ exports[`won't compile if output oc controller is wrong (type) should match snap
                 Type 'number' is not assignable to type 'string'."
 `;
 
-exports[`won't compile if trying to access non defined body (type) should match snapshot 1`] = `"Property 'foo' does not exist on type 'undefined'."`;
+exports[`won't compile if trying to access non defined body (type) should match snapshot 1`] = `"Property 'foo' does not exist on type '{}'."`;
 
 exports[`won't compile if trying to access non existent param (type) should match snapshot 1`] = `"Property 'baz' does not exist on type 'CodecRecordOutput<{ auth: StringC; }>'."`;

--- a/packages/ts-endpoint-express/src/__typetests__/addEndpoint.typespec.ts
+++ b/packages/ts-endpoint-express/src/__typetests__/addEndpoint.typespec.ts
@@ -4,7 +4,7 @@ import * as t from 'io-ts';
 import * as express from 'express';
 import { right } from 'fp-ts/lib/Either';
 
-const endpoint = Endpoint({
+const getEndpoint = Endpoint({
   Input: {
     Params: { id: t.string },
     Headers: { auth: t.string },
@@ -20,25 +20,41 @@ const router = express.Router();
 AddEndpoint();
 
 // @dts-jest:fail:snap won't compile if output oc controller is wrong
-AddEndpoint(router)(endpoint, ({ headers: { auth }, params: { id } }) => () => {
+AddEndpoint(router)(getEndpoint, ({ headers: { auth }, params: { id } }) => () => {
   console.log(auth, id);
   return Promise.resolve(right({ body: { crayons: [22] }, statusCode: 200 }));
 });
 
 // @dts-jest:fail:snap won't compile if trying to access non existent param
-AddEndpoint(router)(endpoint, ({ headers: { baz }, params: { id } }) => () => {
+AddEndpoint(router)(getEndpoint, ({ headers: { baz }, params: { id } }) => () => {
   console.log(baz, id);
   return Promise.resolve(right({ body: { crayons: ['brown'] }, statusCode: 200 }));
 });
 
 // @dts-jest:fail:snap won't compile if trying to access non defined body
-AddEndpoint(router)(endpoint, ({ headers: { auth }, params: { id }, body: { foo } }) => () => {
+AddEndpoint(router)(getEndpoint, ({ headers: { auth }, params: { id }, body: { foo } }) => () => {
   console.log(auth, id, foo);
   return Promise.resolve(right({ body: { crayons: ['brown'] }, statusCode: 200 }));
 });
 
 // @dts-jest:pass:snap correct constructions should work
-AddEndpoint(router)(endpoint, ({ headers: { auth }, params: { id } }) => () => {
+AddEndpoint(router)(getEndpoint, ({ headers: { auth }, params: { id } }) => () => {
   console.log(auth, id);
   return Promise.resolve(right({ body: { crayons: ['brown'] }, statusCode: 200 }));
+});
+
+
+const postEndpoint = Endpoint({
+  Input: {
+    Body: t.type({ content: t.string })
+  },
+  Method: 'POST',
+  getPath: ({ id }) => `users/${id}/crayons`,
+  Output: t.type({ crayons: t.array(t.string) }),
+});
+
+// @dts-jest:pass:snap correct constructions should work
+AddEndpoint(router)(postEndpoint, ({ body: { content } }) => () => {
+  console.log(content);
+  return Promise.resolve(right({ body: { crayons: ['brown'] }, statusCode: 201 }));
 });

--- a/packages/ts-endpoint-express/src/__typetests__/addEndpoint.typespec.ts
+++ b/packages/ts-endpoint-express/src/__typetests__/addEndpoint.typespec.ts
@@ -43,13 +43,12 @@ AddEndpoint(router)(getEndpoint, ({ headers: { auth }, params: { id } }) => () =
   return Promise.resolve(right({ body: { crayons: ['brown'] }, statusCode: 200 }));
 });
 
-
 const postEndpoint = Endpoint({
   Input: {
-    Body: t.type({ content: t.string })
+    Body: t.type({ content: t.string }),
   },
   Method: 'POST',
-  getPath: ({ id }) => `users/${id}/crayons`,
+  getPath: () => `users/crayons`,
   Output: t.type({ crayons: t.array(t.string) }),
 });
 

--- a/packages/ts-endpoint-express/src/index.ts
+++ b/packages/ts-endpoint-express/src/index.ts
@@ -57,7 +57,7 @@ export type AddEndpoint = (
     OutputOrNever<P>,
     OutputOrNever<H>,
     OutputOrNever<Q>,
-    B extends t.Type<any, any, any> ? t.TypeOf<B> : never,
+    B extends undefined ? undefined : B extends t.Type<any, any, any> ? t.TypeOf<B> : undefined,
     t.TypeOf<O>
   >
 ) => void;

--- a/packages/ts-endpoint-express/src/index.ts
+++ b/packages/ts-endpoint-express/src/index.ts
@@ -1,4 +1,4 @@
-import { EndpointInstance, Endpoint } from 'ts-endpoint';
+import { EndpointInstance, Endpoint, HTTPMethod } from 'ts-endpoint';
 import * as t from 'io-ts';
 import * as express from 'express';
 import { Controller } from './Controller';
@@ -44,19 +44,20 @@ export type AddEndpoint = (
   router: express.Router,
   ...m: express.RequestHandler[]
 ) => <
+  M extends HTTPMethod,
   O extends t.Type<any, any, any>,
   H extends { [k: string]: t.Type<any, any, any> } | undefined = undefined,
   Q extends { [k: string]: t.Type<any, any, any> } | undefined = undefined,
   B extends t.Type<any, any, any> | undefined = undefined,
   P extends { [k: string]: t.Type<any, any, any> } | undefined = undefined
 >(
-  e: EndpointInstance<Endpoint<any, O, H, Q, B, P>>,
+  e: EndpointInstance<Endpoint<M, O, H, Q, B, P>>,
   c: Controller<
     IOError,
     OutputOrNever<P>,
     OutputOrNever<H>,
     OutputOrNever<Q>,
-    OutputOrNever<B>,
+    B extends t.Type<any, any, any> ? t.TypeOf<B> : never,
     t.TypeOf<O>
   >
 ) => void;

--- a/packages/ts-endpoint/src/Endpoint/Endpoint.ts
+++ b/packages/ts-endpoint/src/Endpoint/Endpoint.ts
@@ -172,9 +172,9 @@ export function Endpoint<
     },
     Input: {
       ...(e.Input.Body !== undefined ? { Body: e.Input.Body } : {}),
-      ...(e.Input.Headers !== undefined ? { Headers: t.type(e.Input.Headers as t.Props) } : {}),
-      ...(e.Input.Params !== undefined ? { Params: t.type(e.Input.Params as t.Props) } : {}),
-      ...(e.Input.Query !== undefined ? { Query: t.type(e.Input.Query as t.Props) } : {}),
+      ...(e.Input.Headers !== undefined ? { Headers: t.type(e.Input.Headers as t.Props, 'Headers') } : {}),
+      ...(e.Input.Params !== undefined ? { Params: t.type(e.Input.Params as t.Props, 'Params') } : {}),
+      ...(e.Input.Query !== undefined ? { Query: t.type(e.Input.Query as t.Props, 'Query') } : {}),
     },
     Opts: e.Opts ?? defaultOps,
   } as unknown) as EndpointInstance<Endpoint<M, O, H, Q, B, P>>;

--- a/packages/ts-endpoint/src/Endpoint/withAuth.ts
+++ b/packages/ts-endpoint/src/Endpoint/withAuth.ts
@@ -23,7 +23,7 @@ export function withAuth<E extends EndpointInstance<any>>(e: E): WithAuth<E> {
     ...e,
     Input: {
       ...e.Input,
-      Headers: t.type(newHeaders),
+      Headers: t.type(newHeaders, 'Headers'),
     },
   } as unknown) as WithAuth<E>;
 }


### PR DESCRIPTION
Endpoint's body type inference is actually broken for express.
I've added a test, but there's an error with old ones as a snapshot update is probably needed.

By the way, happy new year 🌈
